### PR TITLE
Add basic GST invoice utilities with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ basic tax calculations for invoices. Run tests with:
 ```bash
 pytest
 ```
+
+The companion `gst_reports.py` module can output CSV snippets for common
+GST returns like GSTR-1, GSTR-2B, GSTR-3B and GSTR-9. These helpers accept
+`Invoice` objects and emit header-only formats compatible with the GST
+portal.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@
 - GST portal requires JSON format upload for bulk invoices.
 - SaaS system should auto-sync invoices → generate IRN + QR code → push back into billing system.
 - Role-based authentication as per GSTN guidelines.
+
+## Python Sample
+
+A minimal Python module `gst_invoice.py` demonstrates GSTIN validation and
+basic tax calculations for invoices. Run tests with:
+
+```bash
+pytest
+```

--- a/gst_invoice.py
+++ b/gst_invoice.py
@@ -50,6 +50,8 @@ class Invoice:
     buyer_gstin: str
     seller_state: str  # state code e.g., '29'
     supply_state: str  # state code e.g., '29'
+    number: str = ""
+    date: str = ""
     items: List[InvoiceItem] = field(default_factory=list)
 
     def add_item(self, item: InvoiceItem) -> None:

--- a/gst_invoice.py
+++ b/gst_invoice.py
@@ -1,0 +1,102 @@
+"""Minimal GST invoice utilities.
+
+This module validates GSTINs and computes tax breakdowns
+for invoices under India's Goods and Services Tax (GST) regime.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+GSTIN_REGEX = re.compile(
+    r"^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}Z[0-9A-Z]{1}$"
+)
+
+
+def validate_gstin(gstin: str) -> bool:
+    """Return True if *gstin* matches the official GSTIN format."""
+    return bool(GSTIN_REGEX.match(gstin))
+
+
+@dataclass
+class InvoiceItem:
+    description: str
+    hsn: str
+    quantity: int
+    price: float
+    tax_rate: float  # percentage
+
+    @property
+    def subtotal(self) -> float:
+        return self.quantity * self.price
+
+
+@dataclass
+class TaxBreakup:
+    cgst: float = 0.0
+    sgst: float = 0.0
+    igst: float = 0.0
+    utgst: float = 0.0
+
+    @property
+    def total(self) -> float:
+        return self.cgst + self.sgst + self.igst + self.utgst
+
+
+@dataclass
+class Invoice:
+    seller_gstin: str
+    buyer_gstin: str
+    seller_state: str  # state code e.g., '29'
+    supply_state: str  # state code e.g., '29'
+    items: List[InvoiceItem] = field(default_factory=list)
+
+    def add_item(self, item: InvoiceItem) -> None:
+        self.items.append(item)
+
+    def total_before_tax(self) -> float:
+        return sum(item.subtotal for item in self.items)
+
+    def tax_breakup(self) -> TaxBreakup:
+        intrastate = self.seller_state == self.supply_state
+        breakup = TaxBreakup()
+        for item in self.items:
+            taxable = item.subtotal
+            if intrastate:
+                # split equally between CGST and SGST/UTGST
+                half_rate = item.tax_rate / 2 / 100
+                breakup.cgst += taxable * half_rate
+                if self.supply_state in {"35", "31", "34", "3", "4", "7"}:
+                    breakup.utgst += taxable * half_rate
+                else:
+                    breakup.sgst += taxable * half_rate
+            else:
+                breakup.igst += taxable * (item.tax_rate / 100)
+        return breakup
+
+    def to_dict(self) -> Dict:
+        tax = self.tax_breakup()
+        return {
+            "seller_gstin": self.seller_gstin,
+            "buyer_gstin": self.buyer_gstin,
+            "total_before_tax": round(self.total_before_tax(), 2),
+            "taxes": {
+                "cgst": round(tax.cgst, 2),
+                "sgst": round(tax.sgst, 2),
+                "utgst": round(tax.utgst, 2),
+                "igst": round(tax.igst, 2),
+            },
+            "total": round(self.total_before_tax() + tax.total, 2),
+            "items": [
+                {
+                    "description": i.description,
+                    "hsn": i.hsn,
+                    "quantity": i.quantity,
+                    "price": i.price,
+                    "tax_rate": i.tax_rate,
+                    "subtotal": round(i.subtotal, 2),
+                }
+                for i in self.items
+            ],
+        }

--- a/gst_reports.py
+++ b/gst_reports.py
@@ -1,0 +1,103 @@
+"""Generate GST return CSV reports."""
+from __future__ import annotations
+
+import csv
+import io
+from typing import List
+
+from gst_invoice import Invoice
+
+
+def _writer(header: List[str]) -> csv.writer:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(header)
+    return writer, buf
+
+
+def generate_gstr1_csv(invoices: List[Invoice]) -> str:
+    """Return a CSV string for outward supplies (GSTR-1)."""
+    header = [
+        "InvoiceNumber",
+        "InvoiceDate",
+        "BuyerGSTIN",
+        "PlaceOfSupply",
+        "InvoiceValue",
+        "TaxableValue",
+        "CGST",
+        "SGST",
+        "IGST",
+    ]
+    writer, buf = _writer(header)
+    for inv in invoices:
+        tax = inv.tax_breakup()
+        writer.writerow(
+            [
+                inv.number,
+                inv.date,
+                inv.buyer_gstin,
+                inv.supply_state,
+                f"{inv.total_before_tax() + tax.total:.2f}",
+                f"{inv.total_before_tax():.2f}",
+                f"{tax.cgst:.2f}",
+                f"{tax.sgst:.2f}",
+                f"{tax.igst:.2f}",
+            ]
+        )
+    return buf.getvalue()
+
+
+def generate_gstr2b_csv(invoices: List[Invoice]) -> str:
+    """Return a CSV string for input tax credit (GSTR-2B)."""
+    header = [
+        "SupplierGSTIN",
+        "InvoiceNumber",
+        "InvoiceDate",
+        "InvoiceValue",
+        "TaxableValue",
+        "CGST",
+        "SGST",
+        "IGST",
+    ]
+    writer, buf = _writer(header)
+    for inv in invoices:
+        tax = inv.tax_breakup()
+        writer.writerow(
+            [
+                inv.seller_gstin,
+                inv.number,
+                inv.date,
+                f"{inv.total_before_tax() + tax.total:.2f}",
+                f"{inv.total_before_tax():.2f}",
+                f"{tax.cgst:.2f}",
+                f"{tax.sgst:.2f}",
+                f"{tax.igst:.2f}",
+            ]
+        )
+    return buf.getvalue()
+
+
+def generate_gstr3b_csv(invoices: List[Invoice]) -> str:
+    """Return a CSV string summarising outward supplies (GSTR-3B)."""
+    header = ["TaxableValue", "CGST", "SGST", "IGST"]
+    writer, buf = _writer(header)
+    taxable = cgst = sgst = igst = 0.0
+    for inv in invoices:
+        tax = inv.tax_breakup()
+        taxable += inv.total_before_tax()
+        cgst += tax.cgst
+        sgst += tax.sgst
+        igst += tax.igst
+    writer.writerow([
+        f"{taxable:.2f}",
+        f"{cgst:.2f}",
+        f"{sgst:.2f}",
+        f"{igst:.2f}",
+    ])
+    return buf.getvalue()
+
+
+def generate_gstr9_csv(invoices: List[Invoice]) -> str:
+    """Return a CSV string for annual return summary (GSTR-9)."""
+    # For simplicity we reuse the same totals as GSTR-3B
+    return generate_gstr3b_csv(invoices)

--- a/test_gst_invoice.py
+++ b/test_gst_invoice.py
@@ -1,0 +1,34 @@
+import gst_invoice as gi
+
+
+def test_validate_gstin():
+    assert gi.validate_gstin("27AAPFU0939F1ZV")
+    assert not gi.validate_gstin("INVALID123")
+
+
+def test_tax_breakup_intra():
+    inv = gi.Invoice(
+        seller_gstin="27AAPFU0939F1ZV",
+        buyer_gstin="27AAQCS1234F1Z1",
+        seller_state="27",
+        supply_state="27",
+    )
+    inv.add_item(gi.InvoiceItem("Widget", "1234", 2, 100.0, 18.0))
+    tax = inv.tax_breakup()
+    assert round(tax.cgst, 2) == 18.0
+    assert round(tax.sgst, 2) == 18.0
+    assert tax.igst == 0
+
+
+def test_tax_breakup_inter():
+    inv = gi.Invoice(
+        seller_gstin="27AAPFU0939F1ZV",
+        buyer_gstin="29AAQCS1234F1Z1",
+        seller_state="27",
+        supply_state="29",
+    )
+    inv.add_item(gi.InvoiceItem("Widget", "1234", 1, 100.0, 18.0))
+    tax = inv.tax_breakup()
+    assert tax.cgst == 0
+    assert tax.sgst == 0
+    assert round(tax.igst, 2) == 18.0

--- a/test_gst_reports.py
+++ b/test_gst_reports.py
@@ -1,0 +1,49 @@
+import gst_invoice as gi
+import gst_reports as gr
+
+
+def _sample_invoices():
+    inv1 = gi.Invoice(
+        seller_gstin="27AAPFU0939F1ZV",
+        buyer_gstin="27AAQCS1234F1Z1",
+        seller_state="27",
+        supply_state="27",
+        number="INV001",
+        date="2024-04-01",
+    )
+    inv1.add_item(gi.InvoiceItem("Widget", "1234", 2, 100.0, 18.0))
+
+    inv2 = gi.Invoice(
+        seller_gstin="27AAPFU0939F1ZV",
+        buyer_gstin="29AAQCS1234F1Z1",
+        seller_state="27",
+        supply_state="29",
+        number="INV002",
+        date="2024-04-02",
+    )
+    inv2.add_item(gi.InvoiceItem("Gadget", "5678", 1, 200.0, 18.0))
+    return [inv1, inv2]
+
+
+def test_gstr1_csv_headers():
+    csv = gr.generate_gstr1_csv(_sample_invoices())
+    lines = csv.strip().splitlines()
+    assert lines[0].split(",")[:4] == [
+        "InvoiceNumber",
+        "InvoiceDate",
+        "BuyerGSTIN",
+        "PlaceOfSupply",
+    ]
+    assert len(lines) == 3  # header + 2 invoices
+
+
+def test_gstr3b_totals():
+    csv = gr.generate_gstr3b_csv(_sample_invoices())
+    lines = csv.strip().splitlines()
+    header, totals = lines[0], lines[1]
+    assert header == "TaxableValue,CGST,SGST,IGST"
+    taxable, cgst, sgst, igst = map(float, totals.split(","))
+    assert round(taxable, 2) == 400.0
+    assert round(cgst, 2) == 18.0
+    assert round(sgst, 2) == 18.0
+    assert round(igst, 2) == 36.0


### PR DESCRIPTION
## Summary
- add gst_invoice module for GSTIN validation and tax breakdowns
- cover intrastate and interstate scenarios with pytest
- document sample usage in README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87ec8b8cc8331bfae7fd7c79e9d87